### PR TITLE
Update  bsd-3-clause.txt

### DIFF
--- a/_licenses/bsd-3-clause.txt
+++ b/_licenses/bsd-3-clause.txt
@@ -9,7 +9,7 @@ permalink: /licenses/bsd-3-clause/
 
 description: A permissive license that comes in two variants, the <a href="/licenses/bsd">BSD 2-Clause</a> and <a href="/licenses/bsd-3-clause">BSD 3-Clause</a>. Both have very minute differences to the MIT license. The three clause variant prohibits others from using the name of the project or its contributors to promote derivative works without written consent.
 
-how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders. Replace {organization} with the organization, if any, that sponsors this work.
+how: Create a text file (typically named LICENSE or LICENSE.txt) in the root of your source code and copy the text of the license into the file. Replace [year] with the current year and [fullname] with the name (or names) of the copyright holders. Replace [project] with the project organization, if any, that sponsors this work.
 
 source: http://opensource.org/licenses/BSD-3-Clause
 


### PR DESCRIPTION
Replace the not exist {organization} option with [project].

The discuss can be found in #109
{organiztion} was changed to [project] in #208

By the way, I think we can use this way in the [opensource.org](http://opensource.org/licenses/BSD-3-Clause):

> 1. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.

Or just keep the original.

Any ideas? :smiley: 
